### PR TITLE
Underline links

### DIFF
--- a/src/frontend/src/styles/app.scss
+++ b/src/frontend/src/styles/app.scss
@@ -25,15 +25,25 @@ a:hover,
 a:focus,
 a {
   color: $themecolor;
-  text-decoration: none;
+  text-decoration: underline;
   &:hover,
   &:focus {
-    color: $themecolor-alt;
+    color: $accentColor;
+    &:visited {
+      color: $accentColor;
+    }
   }
   &:visited {
     color: $themecolor;
   }
 }
+
+.mat-table {
+  a {
+    text-decoration: none !important;
+  }
+}
+
 a.link {
   color: $themecolor;
   text-decoration: none;


### PR DESCRIPTION
As per request from Joyce - vendors are getting confused as they cannot tell what is a link vs text. Have made the changes needed (underlined links).