### PR TITLE
List sorting and pagination

### DIFF
--- a/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
@@ -58,10 +58,9 @@
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>
-            <!-- Hiding pagination until fixed -->
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
@@ -46,21 +46,13 @@
                 </td>
               </ng-container>
 
-              <ng-container matColumnDef="noData">
-                <mat-footer-cell *matFooterCellDef [attr.colspan]="displayedColumns.length">
-                  <p>Unable to find that business. Please make sure you have entered the correct terms.</p>
-                </mat-footer-cell>
-              </ng-container>
-
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="notFound">
-                <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
-              </ng-container>
             </table>
           </div>
         </div>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">Unable to find that business. Please make sure you have entered the correct terms.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.html
@@ -35,8 +35,8 @@
             <button mat-stroked-button type="submit" style="height: 68%; width: 100%; margin: .25em 0;"><mat-icon>search</mat-icon></button>
           </div>
         </form>
-        <div *ngIf="!workInProgress">
-          <div class="mat-elevation-z8" *ngIf="!hideTable">
+        <div [hidden]="workInProgress">
+          <div class="mat-elevation-z8" [hidden]="hideTable">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
               <ng-container matColumnDef="businessName">

--- a/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.ts
+++ b/src/frontend/src/app/components/admin/admin-business-list/admin-business-list.component.ts
@@ -31,6 +31,7 @@ export class AdminBusinessListComponent implements OnInit {
   userName = '';
   userEmail= '';
   isAdmin;
+  _ = _;
 
   public businessSearchForm = new FormGroup({
     search: new FormControl(''),
@@ -69,6 +70,8 @@ export class AdminBusinessListComponent implements OnInit {
         }
         else {
           this.dataSource = new MatTableDataSource(res);
+          this.dataSource.paginator = this.paginator;
+          this.dataSource.sort = this.sort;
           this.notFound = false;
         }
       },

--- a/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
@@ -31,20 +31,13 @@
                 <th class="cell-right" mat-header-cell *matHeaderCellDef mat-sort-header>Amount</th>
                 <td class="cell-right" mat-cell *matCellDef="let row">{{ row.netPayment | currency }}</td>
               </ng-container>
-              <ng-container matColumnDef="noData">
-                <mat-footer-cell *matFooterCellDef [attr.colspan]="displayedColumns.length">
-                  There are no payment records for this business.
-                </mat-footer-cell>
-              </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
-                <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
-              </ng-container>
             </table>
           </div>
         </div>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">There are no payment records for this business.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
@@ -42,9 +42,9 @@
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.html
@@ -11,7 +11,7 @@
         </button>
       </mat-card-header>
       <mat-card-content>
-        <div *ngIf="!workInProgress">
+        <div [hidden]="workInProgress">
           <div class="mat-elevation-z8">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
@@ -38,7 +38,7 @@
               </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="dataSource.data.length === 0">
+              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>

--- a/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.ts
+++ b/src/frontend/src/app/components/admin/admin-business-payments/admin-business-payments.component.ts
@@ -6,6 +6,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { VendorPaymentSummary } from 'src/app/model';
 import { VendorService } from 'src/app/providers';
 import { saveAs } from 'file-saver';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-admin-business-payments',
@@ -25,6 +26,7 @@ export class AdminBusinessPaymentsComponent implements OnInit {
   sort: MatSort;
   public workInProgress = false;
   private vendorId: string;
+  _ = _;
 
   constructor(
     private vendorService: VendorService,

--- a/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
@@ -82,9 +82,9 @@
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
@@ -15,7 +15,7 @@
           <mat-label>Search</mat-label>
           <input matInput (keyup)="applyFilter($event)" placeholder="Search for voucher by Order #, Voucher ID, Customer Name or Customer Email">
         </mat-form-field>
-        <div *ngIf="!workInProgress">
+        <div [hidden]="workInProgress">
           <div class="mat-elevation-z8">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
@@ -78,7 +78,7 @@
               </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="dataSource.data.length === 0">
+              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>

--- a/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
+++ b/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.html
@@ -71,20 +71,13 @@
                 <th class="cell-right" mat-header-cell *matHeaderCellDef mat-sort-header>Donation</th>
                 <td class="cell-right" mat-cell *matCellDef="let row">{{ row.voucherIsDonation | yesNo }}</td>
               </ng-container>
-              <ng-container matColumnDef="noData">
-                <mat-footer-cell *matFooterCellDef [attr.colspan]="displayedColumns.length">
-                  No voucher records.
-                </mat-footer-cell>
-              </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
-                <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
-              </ng-container>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>              
             </table>
           </div>
         </div>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">There are no vouchers for this business.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.ts
+++ b/src/frontend/src/app/components/admin/admin-business-vouchers/admin-business-vouchers.component.ts
@@ -6,6 +6,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { VendorService } from 'src/app/providers';
 import { saveAs } from 'file-saver';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-admin-business-vouchers',
@@ -34,6 +35,7 @@ export class AdminBusinessVouchersComponent implements OnInit {
   sort: MatSort;
   public workInProgress = false;
   private vendorId: string;
+  _ = _;
 
   constructor(
     private vendorService: VendorService,

--- a/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
@@ -28,23 +28,15 @@
                 </td>
               </ng-container>
 
-              <ng-container matColumnDef="noData">
-                <mat-footer-cell *matFooterCellDef [attr.colspan]="displayedColumns.length">
-                  <p>You don't have any businesses linked to your account yet. <a href="/new-vendor">Click here to register a new one. </a>If this isn't what you expect, please email <a href="mailto:portal@sosbusiness.nz" target="_blank">portal@sosbusiness.nz</a> and we will help.</p>
-                </mat-footer-cell>
-              </ng-container>
-
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
-                <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
-              </ng-container>
             </table>
           </div>
         </div>
         <br>
         <a href="http://sosbusiness.nz/pages/vendor-portal" target="_blank">Having problems? Check out our frequently asked questions.</a>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">You don't have any businesses linked to your account yet. <a href="/new-vendor">Click here to register a new one. </a>If this isn't what you expect, please email <a href="mailto:portal@sosbusiness.nz" target="_blank">portal@sosbusiness.nz</a> and we will help.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
@@ -17,7 +17,7 @@
           <mat-label>Search</mat-label>
           <input matInput (keyup)="applyFilter($event)" placeholder="Type business name">
         </mat-form-field>
-        <div *ngIf="!workInProgress">
+        <div [hidden]="workInProgress">
           <div class="mat-elevation-z8">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
@@ -36,7 +36,7 @@
 
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="dataSource.data.length === 0">
+              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>

--- a/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.html
@@ -40,12 +40,11 @@
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>
-            <!-- Hiding pagination until fixed -->
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
         <br>
         <a href="http://sosbusiness.nz/pages/vendor-portal" target="_blank">Having problems? Check out our frequently asked questions.</a>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.ts
+++ b/src/frontend/src/app/components/vendor/vendor-list/vendor-list.component.ts
@@ -4,6 +4,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { VendorService } from 'src/app/providers';
 import { VendorSummary } from 'src/app/model';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-vendor-list',
@@ -17,6 +18,7 @@ export class VendorListComponent implements OnInit {
   @ViewChild(MatSort, { static: true })
   sort: MatSort;
   public workInProgress = false;
+  _ = _;
 
   constructor(private vendorService: VendorService) {}
 

--- a/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
@@ -45,6 +45,7 @@
           </div>
         </div>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">There are no payment records for this business.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
@@ -41,11 +41,10 @@
               <ng-container *ngIf="dataSource.data.length === 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
-
             </table>
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.html
@@ -11,7 +11,7 @@
         </button>
       </mat-card-header>
       <mat-card-content>
-        <div *ngIf="!workInProgress">
+        <div [hidden]="workInProgress">
           <div class="mat-elevation-z8">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
@@ -38,7 +38,7 @@
               </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="dataSource.data.length === 0">
+              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>

--- a/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.ts
+++ b/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.ts
@@ -6,6 +6,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { VendorPaymentSummary } from 'src/app/model';
 import { VendorService } from 'src/app/providers';
 import { saveAs } from 'file-saver';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-vendor-payments',
@@ -25,11 +26,13 @@ export class VendorPaymentsComponent implements OnInit {
   sort: MatSort;
   public workInProgress = false;
   private vendorId: string;
+  _ = _;
 
   constructor(
     private vendorService: VendorService,
     private route: ActivatedRoute
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
     this.workInProgress = true;

--- a/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.ts
+++ b/src/frontend/src/app/components/vendor/vendor-payments/vendor-payments.component.ts
@@ -22,7 +22,7 @@ export class VendorPaymentsComponent implements OnInit {
   dataSource: MatTableDataSource<VendorPaymentSummary>;
   @ViewChild(MatPaginator, { static: true })
   paginator: MatPaginator;
-  @ViewChild(MatSort, { static: true })
+  @ViewChild(MatSort, { static: false })
   sort: MatSort;
   public workInProgress = false;
   private vendorId: string;

--- a/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
@@ -82,9 +82,9 @@
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>
-            <!-- <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator> -->
           </div>
         </div>
+        <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
@@ -15,7 +15,7 @@
           <mat-label>Search</mat-label>
           <input matInput (keyup)="applyFilter($event)" placeholder="Search for voucher by Order #, Voucher ID, Customer Email or Customer Name">
         </mat-form-field>
-        <div *ngIf="!workInProgress">
+        <div [hidden]="workInProgress">
           <div class="mat-elevation-z8">
             <table mat-table [dataSource]="dataSource" matSort>
               <!-- Business Name Column -->
@@ -78,7 +78,7 @@
               </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="dataSource.data.length === 0">
+              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
                 <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
               </ng-container>
             </table>

--- a/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
+++ b/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.html
@@ -71,20 +71,13 @@
                 <th class="cell-right" mat-header-cell *matHeaderCellDef mat-sort-header>Donation</th>
                 <td class="cell-right" mat-cell *matCellDef="let row">{{ row.voucherIsDonation | yesNo }}</td>
               </ng-container>
-              <ng-container matColumnDef="noData">
-                <mat-footer-cell *matFooterCellDef [attr.colspan]="displayedColumns.length">
-                  No voucher records.
-                </mat-footer-cell>
-              </ng-container>
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-              <ng-container *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0">
-                <mat-footer-row *matFooterRowDef="['noData']" ></mat-footer-row>
-              </ng-container>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>              
             </table>
           </div>
         </div>
         <mat-paginator [class.visible]="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length > 0" [pageSizeOptions]="[10, 25, 50, 100]"></mat-paginator>
+        <p *ngIf="!_.isUndefined(dataSource) && _.get(dataSource,'data',[]).length == 0">There are no vouchers for this business.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.ts
+++ b/src/frontend/src/app/components/vendor/vendor-vouchers/vendor-vouchers.component.ts
@@ -6,6 +6,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { VendorService } from 'src/app/providers';
 import { saveAs } from 'file-saver';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-vendor-vouchers',
@@ -34,7 +35,8 @@ export class VendorVouchersComponent implements OnInit {
   sort: MatSort;
   public workInProgress = false;
   private vendorId: string;
-
+  _ = _;
+  
   constructor(
     private vendorService: VendorService,
     private route: ActivatedRoute

--- a/src/frontend/src/styles/app.scss
+++ b/src/frontend/src/styles/app.scss
@@ -822,3 +822,11 @@ list inline
     }
   }
 }
+mat-paginator{
+  margin-top: -50px;
+  visibility: hidden;
+}
+.visible{
+  margin-top: 30px;
+  visibility: visible;
+}


### PR DESCRIPTION
Sorting & Pagination completed for
1. Admin voucher
2. Admin payments
3. Admin business list
4. Vendor voucher
5. Vendor payment
6. Vendor list

[note]: Mat paginator sorting can only happen on string columns. Number columns (list amount) can not be sorted. To enable sorting, either convert those to string (can use an api middleware to avoid changing schema) or use a different paginator (too much hassle).